### PR TITLE
Fixes to handout noticed during day 2.

### DIFF
--- a/handout/09-unit-testing-services.md
+++ b/handout/09-unit-testing-services.md
@@ -42,7 +42,7 @@ We'll be mostly running our tools via Gulp, replying on our `rangle-gulp`
 module. So, Gulp is the only tool we need to setup globally.
 
 ```bash
-  sudo npm install -g gulp
+  npm install -g gulp
   npm install
   bower install
 ```
@@ -50,7 +50,7 @@ module. So, Gulp is the only tool we need to setup globally.
 However, let's install Mocha as well, so that we can try using it manually:
 
 ```bash
-  sudo npm install -g mocha
+  npm install -g mocha
 ```
 
 Now we can proceed to writing tests.
@@ -79,7 +79,7 @@ into `client/app/simple.test.js`.
 We can now run this code with:
 
 ```bash
-  mocha client/app/simple_test.js
+  mocha client/app/simple.test.js
 ```
 
 ## The Importance of Test Documentation

--- a/handout/11-ui-router.md
+++ b/handout/11-ui-router.md
@@ -61,18 +61,22 @@ We'll also need to add a directive for ui-router in index.html:
 
 Your index.html main section should now look like this:
 
-```
+```html
+  ...
+
   <body ng-app="ngcourse">
     <div>
      <div ui-view></div>
     </div>
 
     <script src="/bower_components/lodash/dist/lodash.js"></script>
+
+  ...
 ```
 
-ui-view is a directive that ui-router users to manage it's views. It will be replaced by the template or templateURL that is configured for each ui-router state.
+`ui-view` is a directive that `ui-router` users to manage its views. It will be replaced by the template or templateURL that is configured for each ui-router state.
 
-All the content we just removed will be added to templates, and ui-router will insert them into ui-view based on state.
+All the content we just removed will be added to templates, and `ui-router` will insert them into `ui-view` based on the current application state.
 
 Let's talk about why this need to happen in the "config" section.
 
@@ -234,7 +238,8 @@ usually produces a more natural experience for the user.
 
 ## Nesting Views
 
-One of the most powerful features of ui-router versus the out-of-the-box AngularJS router is nested views. To enable ui-router to know what view it's update, we can add a name to the view as seen in `ui-view="child@parent"` below.
+One of the most powerful features of ui-router versus the out-of-the-box AngularJS router is nested views. To allow `ui-router` to know what view it's updating, we can add a
+name to the view as seen in `ui-view="child@parent"` below.
 
 ```javascript
   .state('parent', {


### PR DESCRIPTION
- No more sudo npm.  If you set things up properly in module 0, sudo
  should never be needed for npm.
- Fixed an error in the command to run simple.test.js directly with
  mocha.
- Copy-editing for the UI-router module.